### PR TITLE
docs: add @bjohansebas to security team

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ _TBA_
 - [Claudio Wunder](https://github.com/ovflowd)
 - [Even Stensberg](https://github.com/evenstensberg)
 - [Rafael Gonzaga](https://github.com/RafaelGSS)
+- [Sebastian Beltran](https://github.com/bjohansebas)
 - [Ulises Gascón](https://github.com/UlisesGascon)
 
 ## Meetings


### PR DESCRIPTION
I would like to join this security group. I already have experience with Express in the security group through initiatives aimed at improving both the public-facing aspects and internal processes.

I would also like to join the triage group, but I’m not sure if I would be accepted or if there are criteria for that at the moment. I’d be happy to help whenever my time and resources allow.