### PR TITLE
docs: security triage members

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The Security Working Group is composed of two groups of members: the Security Tr
 
 ### Security Triage Team @webpack/security-triage
 
+- [Aviv Keller](https://github.com/avivkeller)
 - [Sebastian Beltran](https://github.com/bjohansebas)
 - [Ulises Gascón](https://github.com/UlisesGascon)
 


### PR DESCRIPTION
To move forward with this group and have it handle reports, please add your name directly or leave a comment so we can add you.

I also think it would be great if someone with sufficient permissions could create the **security-triage** team and add us as security managers for this organization, so everyone on that team can have access to the reports that are created.


cc: @webpack/security-wg 