### PR TITLE
docs: Remove lead members section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ The Security Working Group is composed of two groups of members: the Security Tr
 - [Sebastian Beltran](https://github.com/bjohansebas)
 - [Ulises Gascón](https://github.com/UlisesGascon)
 
-### Lead Members @webpack/security-wg-leads
-
-_TBA_
-
 ### Team Members @webpack/security-wg
 
 - [Aviv Keller](https://github.com/avivkeller)


### PR DESCRIPTION
Does having this team serve any purpose, or can we delete it? Anyway, this group is for teamwork, not the responsibility of a single person or of the people listed there.
